### PR TITLE
Fix: check if DB_NAME is defined before using it

### DIFF
--- a/src/Controllers/Version4/Utilities/DatabaseInformation.php
+++ b/src/Controllers/Version4/Utilities/DatabaseInformation.php
@@ -30,80 +30,87 @@ class DatabaseInformation {
 	public function get_database_info() {
 		global $wpdb;
 
-		$database_table_information = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT
-				    table_name AS 'name',
-					engine AS 'engine',
-				    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
-				    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
-				FROM information_schema.TABLES
-				WHERE table_schema = %s
-				ORDER BY name ASC;",
-				DB_NAME
-			)
-		);
+		$tables        = array();
+		$database_size = array();
 
-		// WC Core tables to check existence of.
-		$core_tables = apply_filters(
-			'woocommerce_database_tables',
-			array(
-				'woocommerce_sessions',
-				'woocommerce_api_keys',
-				'woocommerce_attribute_taxonomies',
-				'woocommerce_downloadable_product_permissions',
-				'woocommerce_order_items',
-				'woocommerce_order_itemmeta',
-				'woocommerce_tax_rates',
-				'woocommerce_tax_rate_locations',
-				'woocommerce_shipping_zones',
-				'woocommerce_shipping_zone_locations',
-				'woocommerce_shipping_zone_methods',
-				'woocommerce_payment_tokens',
-				'woocommerce_payment_tokenmeta',
-				'woocommerce_log',
-			)
-		);
-
-		/**
-		 * Adding the prefix to the tables array, for backwards compatibility.
-		 *
-		 * If we changed the tables above to include the prefix, then any filters against that table could break.
-		 */
-		$core_tables = array_map( array( $this, 'add_db_table_prefix' ), $core_tables );
-
-		/**
-		 * Organize WooCommerce and non-WooCommerce tables separately for display purposes later.
-		 *
-		 * To ensure we include all WC tables, even if they do not exist, pre-populate the WC array with all the tables.
-		 */
-		$tables = array(
-			'woocommerce' => array_fill_keys( $core_tables, false ),
-			'other'       => array(),
-		);
-
-		$database_size = array(
-			'data'  => 0,
-			'index' => 0,
-		);
-
-		$site_tables_prefix = $wpdb->get_blog_prefix( get_current_blog_id() );
-		$global_tables      = $wpdb->tables( 'global', true );
-		foreach ( $database_table_information as $table ) {
-			// Only include tables matching the prefix of the current site, this is to prevent displaying all tables on a MS install not relating to the current.
-			if ( is_multisite() && 0 !== strpos( $table->name, $site_tables_prefix ) && ! in_array( $table->name, $global_tables, true ) ) {
-				continue;
-			}
-			$table_type = in_array( $table->name, $core_tables, true ) ? 'woocommerce' : 'other';
-
-			$tables[ $table_type ][ $table->name ] = array(
-				'data'   => $table->data,
-				'index'  => $table->index,
-				'engine' => $table->engine,
+		// It is not possible to get the database name from some classes that replace wpdb (e.g., HyperDB)
+		// and that is why this if condition is needed.
+		if ( defined( 'DB_NAME' ) ) {
+			$database_table_information = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT
+					    table_name AS 'name',
+						engine AS 'engine',
+					    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
+					    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
+					FROM information_schema.TABLES
+					WHERE table_schema = %s
+					ORDER BY name ASC;",
+					DB_NAME
+				)
 			);
 
-			$database_size['data']  += $table->data;
-			$database_size['index'] += $table->index;
+			// WC Core tables to check existence of.
+			$core_tables = apply_filters(
+				'woocommerce_database_tables',
+				array(
+					'woocommerce_sessions',
+					'woocommerce_api_keys',
+					'woocommerce_attribute_taxonomies',
+					'woocommerce_downloadable_product_permissions',
+					'woocommerce_order_items',
+					'woocommerce_order_itemmeta',
+					'woocommerce_tax_rates',
+					'woocommerce_tax_rate_locations',
+					'woocommerce_shipping_zones',
+					'woocommerce_shipping_zone_locations',
+					'woocommerce_shipping_zone_methods',
+					'woocommerce_payment_tokens',
+					'woocommerce_payment_tokenmeta',
+					'woocommerce_log',
+				)
+			);
+
+			/**
+			 * Adding the prefix to the tables array, for backwards compatibility.
+			 *
+			 * If we changed the tables above to include the prefix, then any filters against that table could break.
+			 */
+			$core_tables = array_map( array( $this, 'add_db_table_prefix' ), $core_tables );
+
+			/**
+			 * Organize WooCommerce and non-WooCommerce tables separately for display purposes later.
+			 *
+			 * To ensure we include all WC tables, even if they do not exist, pre-populate the WC array with all the tables.
+			 */
+			$tables = array(
+				'woocommerce' => array_fill_keys( $core_tables, false ),
+				'other'       => array(),
+			);
+
+			$database_size = array(
+				'data'  => 0,
+				'index' => 0,
+			);
+
+			$site_tables_prefix = $wpdb->get_blog_prefix( get_current_blog_id() );
+			$global_tables      = $wpdb->tables( 'global', true );
+			foreach ( $database_table_information as $table ) {
+				// Only include tables matching the prefix of the current site, this is to prevent displaying all tables on a MS install not relating to the current.
+				if ( is_multisite() && 0 !== strpos( $table->name, $site_tables_prefix ) && ! in_array( $table->name, $global_tables, true ) ) {
+					continue;
+				}
+				$table_type = in_array( $table->name, $core_tables, true ) ? 'woocommerce' : 'other';
+
+				$tables[ $table_type ][ $table->name ] = array(
+					'data'   => $table->data,
+					'index'  => $table->index,
+					'engine' => $table->engine,
+				);
+
+				$database_size['data']  += $table->data;
+				$database_size['index'] += $table->index;
+			}
 		}
 
 		// Return all database info. Described by JSON Schema.


### PR DESCRIPTION
The WooCommerce REST API relies on the constant DB_NAME to display information about the database tables in the system status page. The problem is that this constant is not always defined (e.g., when the plugin HyperDB is used to replace the standard wpdb class). When that is the case, WooCommerce will incorrectly say that its core tables are missing and the following PHP warning will be generated:

```
Use of undefined constant DB_NAME - assumed 'DB_NAME' (this will throw an Error in a future version of PHP)
wp-content/plugins/woocommerce/includes/api/v2/class-wc-rest-system-status-v2-controller.php:708
```

To fix this, this commit checks to see if DB_NAME is defined before using it. When the constant is not set, WooCommerce will not try to get information about the tables.

https://github.com/woocommerce/woocommerce/pull/24034 uses the changes here to display a message to the users in the system status page saying that it was not possible to get information on the tables instead of showing that the tables are missing.

For more information see https://github.com/woocommerce/woocommerce/issues/23508