### PR TITLE
Use WP_UnitTestCase::assertWPError() instead of WC_Unit_Test_Case::assertIsWPError()

### DIFF
--- a/unit-tests/Tests/Version2/settings.php
+++ b/unit-tests/Tests/Version2/settings.php
@@ -163,7 +163,7 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test route callback receiving an empty group id
 		$result = $this->endpoint->get_group_settings( '' );
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 
 		// test getting a group that does not exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/not-real' ) );
@@ -344,7 +344,7 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 	public function test_get_setting_empty_setting_id() {
 		$result = $this->endpoint->get_setting( 'test', '' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**
@@ -355,7 +355,7 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 	public function test_get_setting_invalid_setting_id() {
 		$result = $this->endpoint->get_setting( 'test', 'invalid' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**
@@ -379,7 +379,7 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		$result = $controller->get_setting( 'test', 'woocommerce_shop_page_display' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**

--- a/unit-tests/Tests/Version3/functions.php
+++ b/unit-tests/Tests/Version3/functions.php
@@ -71,7 +71,7 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 		$expected_error_message = 'Error getting remote image http://somedomain.com/nonexistent-image.png. Error: Not found.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/nonexistent-image.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 	}
 
@@ -85,14 +85,14 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 		$expected_error_message = 'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini or by post_max_size being defined as smaller than upload_max_filesize in php.ini.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-1.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 
 		// unsupported mime type.
 		$expected_error_message = 'Invalid image: Sorry, this file type is not permitted for security reasons.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-2.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 	}
 

--- a/unit-tests/Tests/Version3/settings.php
+++ b/unit-tests/Tests/Version3/settings.php
@@ -164,7 +164,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test route callback receiving an empty group id
 		$result = $this->endpoint->get_group_settings( '' );
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 
 		// test getting a group that does not exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/not-real' ) );
@@ -345,7 +345,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 	public function test_get_setting_empty_setting_id() {
 		$result = $this->endpoint->get_setting( 'test', '' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**
@@ -356,7 +356,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 	public function test_get_setting_invalid_setting_id() {
 		$result = $this->endpoint->get_setting( 'test', 'invalid' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**
@@ -380,7 +380,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		$result = $controller->get_setting( 'test', 'woocommerce_shop_page_display' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**

--- a/unit-tests/Tests/Version4/Settings.php
+++ b/unit-tests/Tests/Version4/Settings.php
@@ -390,7 +390,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		$result = $controller->get_setting( 'test', 'woocommerce_shop_page_display' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 	}
 
 	/**


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce/pull/24207