### PR TITLE
filter empty objects from results before loop

### DIFF
--- a/src/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -337,7 +337,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		}
 
 		return array(
-			'objects' => array_map( array( $this, 'get_object' ), $result ),
+			'objects' => array_filter( array_map( array( $this, 'get_object' ), $result ) ),
 			'total'   => (int) $total_posts,
 			'pages'   => (int) ceil( $total_posts / (int) $query->query_vars['posts_per_page'] ),
 		);

--- a/src/Controllers/Version4/AbstractObjectsController.php
+++ b/src/Controllers/Version4/AbstractObjectsController.php
@@ -271,7 +271,7 @@ abstract class AbstractObjectsController extends AbstractController {
 		}
 
 		return array(
-			'objects' => array_map( array( $this, 'get_object' ), $result ),
+			'objects' => array_filter( array_map( array( $this, 'get_object' ), $result ) ),
 			'total'   => (int) $total_posts,
 			'pages'   => (int) ceil( $total_posts / (int) $query->query_vars['posts_per_page'] ),
 		);


### PR DESCRIPTION
Fixes #13 by filtering out empty/falsey objects before returning them for the loop.