### PR TITLE
Include modified in orderby filter

### DIFF
--- a/src/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -584,6 +584,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				'include',
 				'title',
 				'slug',
+				'modified',
 			),
 			'validate_callback'  => 'rest_validate_request_arg',
 		);

--- a/src/Controllers/Version3/class-wc-rest-customers-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-customers-controller.php
@@ -304,4 +304,16 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 
 		return $this->add_additional_fields_schema( $schema );
 	}
+
+    /**
+	 * Add new options for 'orderby' to the collection params.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+    		$params                    = parent::get_collection_params();
+    		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'modified' ) );
+
+    		return $params;
+    	}
 }

--- a/src/Controllers/Version3/class-wc-rest-posts-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-posts-controller.php
@@ -673,6 +673,7 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 				'include',
 				'title',
 				'slug',
+				'modified',
 			),
 			'validate_callback'  => 'rest_validate_request_arg',
 		);


### PR DESCRIPTION
Partially resolves issue #37. This adds modified option in orderby filter, 
lets you do ```/wp-json/wc/v3/products?orderby=modified```