### PR TITLE
Reintroduced "post_type_counts" in System Status

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -554,14 +554,14 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 					),
 				),
 				'post_type_counts' => array(
-                    'description' => __('Total post count.', 'woocommerce'),
-                    'type'        => 'array',
-                    'context'     => array( 'view' ),
-                    'readonly'    => true,
-                    'items'       => array(
-                        'type' => 'string',
-                    ),
-                ),
+					'description' => __( 'Total post count.', 'woocommerce-rest-api' ),
+					'type'        => 'array',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
 			),
 		);
 

--- a/unit-tests/Tests/Version2/system-status.php
+++ b/unit-tests/Tests/Version2/system-status.php
@@ -207,7 +207,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 9, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'environment', $properties );
 		$this->assertArrayHasKey( 'database', $properties );
 		$this->assertArrayHasKey( 'active_plugins', $properties );

--- a/unit-tests/Tests/Version3/system-status.php
+++ b/unit-tests/Tests/Version3/system-status.php
@@ -210,7 +210,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 9, count( $properties ) );
+		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'environment', $properties );
 		$this->assertArrayHasKey( 'database', $properties );
 		$this->assertArrayHasKey( 'active_plugins', $properties );


### PR DESCRIPTION
For some reason this got removed from the version 2 and 3 of our REST API.
