### PR TITLE
Fix Products Controller images property type

### DIFF
--- a/src/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/src/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -2146,7 +2146,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 				),
 				'images' => array(
 					'description' => __( 'List of images.', 'woocommerce-rest-api' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
 						'type'       => 'object',

--- a/src/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1122,7 +1122,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				),
 				'images'                => array(
 					'description' => __( 'List of images.', 'woocommerce-rest-api' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => array(
 						'type'       => 'object',


### PR DESCRIPTION
I know changes in an API generally not desired, but this only affects values in the schema.

And the behaviour was already correct.

Fix Issue #76