### PR TITLE
Make product_id non mandatory while updating a line_item in orders endpoint

### DIFF
--- a/src/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/src/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -660,7 +660,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 	 */
 	protected function prepare_line_items( $posted, $action = 'create' ) {
 		$item    = new WC_Order_Item_Product( ! empty( $posted['id'] ) ? $posted['id'] : '' );
-		$product = wc_get_product( $this->get_product_id( $posted, $item->get_product() ) );
+		$product = wc_get_product( $this->get_product_id( $posted, $action ) );
 
 		if ( $product && $product !== $item->get_product() ) {
 			$item->set_product( $product );

--- a/src/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -591,18 +591,18 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 *
 	 * @throws WC_REST_Exception When SKU or ID is not valid.
 	 * @param array           $posted Request data.
-	 * @param WC_Product|bool $product Product data.
+	 * @param string          $action 'create' to add line item or 'update' to update it.
 	 * @return int
 	 */
-	protected function get_product_id( $posted, $product ) {
+	protected function get_product_id( $posted, $action = 'create' ) {
 		if ( ! empty( $posted['sku'] ) ) {
 			$product_id = (int) wc_get_product_id_by_sku( $posted['sku'] );
 		} elseif ( ! empty( $posted['product_id'] ) && empty( $posted['variation_id'] ) ) {
 			$product_id = (int) $posted['product_id'];
 		} elseif ( ! empty( $posted['variation_id'] ) ) {
 			$product_id = (int) $posted['variation_id'];
-		} elseif ( $product && 0 < $product->get_id() ) {
-			return $product->get_id();
+		} elseif ( 'update' === $action ) {
+			$product_id = 0;
 		} else {
 			throw new WC_REST_Exception( 'woocommerce_rest_required_product_reference', __( 'Product ID or SKU is required.', 'woocommerce-rest-api' ), 400 );
 		}
@@ -663,9 +663,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	protected function prepare_line_items( $posted, $action = 'create', $item = null ) {
 		$item    = is_null( $item ) ? new WC_Order_Item_Product( ! empty( $posted['id'] ) ? $posted['id'] : '' ) : $item;
-		$product = wc_get_product( $this->get_product_id( $posted, $item->get_product() ) );
+		$product = wc_get_product( $this->get_product_id( $posted, $action ) );
 
-		if ( $product !== $item->get_product() ) {
+		if ( $product && $product !== $item->get_product() ) {
 			$item->set_product( $product );
 
 			if ( 'create' === $action ) {

--- a/unit-tests/Tests/Version2/orders.php
+++ b/unit-tests/Tests/Version2/orders.php
@@ -464,7 +464,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$expected = array(
-			'id'           => 1,
+			'id'           => $item->get_id(),
 			'name'         => 'Dummy Product',
 			'product_id'   => 0,
 			'variation_id' => 0,

--- a/unit-tests/Tests/Version2/orders.php
+++ b/unit-tests/Tests/Version2/orders.php
@@ -340,7 +340,31 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			)
 		);
 		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Tests create an order with an invalid product.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_create_order_with_invalid_product() {
+		wp_set_current_user( $this->user );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v2/orders' );
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'quantity' => 2,
+					),
+				),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
+		$this->assertEquals( 'woocommerce_rest_required_product_reference', $data['code'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
@@ -409,6 +433,55 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( empty( $data['fee_lines'] ) );
+	}
+
+	/**
+	 * Tests updating an order after deleting a product.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_update_order_after_delete_product() {
+		wp_set_current_user( $this->user );
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( 1, $product );
+		$product->delete( true );
+
+		$request    = new WP_REST_Request( 'PUT', '/wc/v2/orders/' . $order->get_id() );
+		$line_items = $order->get_items( 'line_item' );
+		$item       = current( $line_items );
+
+		$request->set_body_params(
+			array(
+				'line_items' => array(
+					array(
+						'id' => $item->get_id(),
+						'quantity'   => 10,
+					),
+				),
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$expected = array(
+			'id'           => 1,
+			'name'         => 'Dummy Product',
+			'product_id'   => 0,
+			'variation_id' => 0,
+			'quantity'     => 10,
+			'tax_class'    => '',
+			'subtotal'     => '40.00',
+			'subtotal_tax' => '0.00',
+			'total'        => '40.00',
+			'total_tax'    => '0.00',
+			'taxes'        => array(),
+			'meta_data'    => array(),
+			'sku'          => null,
+			'price'        => 4,
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected, $data['line_items'][0] );
 	}
 
 	/**

--- a/unit-tests/Tests/Version3/orders.php
+++ b/unit-tests/Tests/Version3/orders.php
@@ -468,7 +468,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$expected = array(
-			'id'           => 1,
+			'id'           => $item->get_id(),
 			'name'         => 'Dummy Product',
 			'product_id'   => 0,
 			'variation_id' => 0,


### PR DESCRIPTION
While updating a `line_item` we only need an ID if we don't want to update the product data.

Closes  #61