### PR TITLE
Added support for filtering products and variations by their menu_order

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -2104,6 +2104,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	public function get_collection_params() {
 		$params = parent::get_collection_params();
 
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'menu_order' ) );
+
 		$params['slug']           = array(
 			'description'       => __( 'Limit result set to products with a specific slug.', 'woocommerce-rest-api' ),
 			'type'              => 'string',

--- a/unit-tests/Tests/Version2/product-variations.php
+++ b/unit-tests/Tests/Version2/product-variations.php
@@ -50,6 +50,24 @@ class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting variations with an orderby clause.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_get_variations_with_orderby() {
+		wp_set_current_user( $this->user );
+		$product    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$request = new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' );
+		$request->set_query_params( array( 'orderby' => 'menu_order' ) );
+		$response   = $this->server->dispatch( $request );
+		$variations = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $variations ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+		$this->assertEquals( 'size', $variations[0]['attributes'][0]['name'] );
+	}
+
+	/**
 	 * Test getting variations without permission.
 	 *
 	 * @since 3.0.0

--- a/unit-tests/Tests/Version3/product-variations.php
+++ b/unit-tests/Tests/Version3/product-variations.php
@@ -50,6 +50,24 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting variations with an orderby clause.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_get_variations_with_orderby() {
+		wp_set_current_user( $this->user );
+		$product    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() . '/variations' );
+		$request->set_query_params( array( 'orderby' => 'menu_order' ) );
+		$response   = $this->server->dispatch( $request );
+		$variations = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $variations ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+		$this->assertEquals( 'size', $variations[0]['attributes'][0]['name'] );
+	}
+
+	/**
 	 * Test getting variations without permission.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
This will add `orderby=menu_order` support to the products v2/v3 and product variation endpoints.

Closes #81.