### PR TITLE
Added menu_order ordering to the v4 product/variation endpoints

### DIFF
--- a/src/Controllers/Version4/Products.php
+++ b/src/Controllers/Version4/Products.php
@@ -804,7 +804,7 @@ class Products extends AbstractObjectsController {
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
-		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating' ) );
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'menu_order', 'price', 'popularity', 'rating' ) );
 
 		return $params;
 	}

--- a/unit-tests/Tests/Version4/ProductVariations.php
+++ b/unit-tests/Tests/Version4/ProductVariations.php
@@ -84,6 +84,23 @@ class ProductVariations extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting variations with an orderby clause.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_get_variations_with_orderby() {
+		$product    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$request = new WP_REST_Request( 'GET', '/wc/v4/products/' . $product->get_id() . '/variations' );
+		$request->set_query_params( array( 'orderby' => 'menu_order' ) );
+		$response   = $this->server->dispatch( $request );
+		$variations = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $variations ) );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+		$this->assertEquals( 'size', $variations[0]['attributes'][0]['name'] );
+	}
+
+	/**
 	 * Test getting a single variation.
 	 *
 	 * @since 3.5.0

--- a/unit-tests/Tests/Version4/Products.php
+++ b/unit-tests/Tests/Version4/Products.php
@@ -93,6 +93,31 @@ class Products extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test getting products with an orderby clause.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_get_products_with_orderby() {
+		// The menu ordering should be the inverse of standard ordering.
+		$product1 = ProductHelper::create_simple_product();
+		$product1->set_menu_order( 1 );
+		$product1->save();
+		$product2 = ProductHelper::create_simple_product();
+		$product2->set_menu_order( 0 );
+		$product2->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc/v4/products' );
+		$request->set_query_params( array( 'orderby' => 'menu_order', 'order' => 'asc' ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$products = $response->get_data();
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( $product2->get_id(), $products[0]['id'] );
+		$this->assertEquals( $product1->get_id(), $products[1]['id'] );
+	}
+
+	/**
 	 * Test getting a single product.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
This adds the same support from #82 to the v4 endpoints.