### PR TITLE
Fix unit test suite in the Travis build jobs

### DIFF
--- a/unit-tests/Tests/Version2/product-variations.php
+++ b/unit-tests/Tests/Version2/product-variations.php
@@ -214,6 +214,8 @@ class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'], print_r( $variation, true ) );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'], print_r( $variation, true ) );
 		$this->assertContains( 'test upload image', $variation['image']['alt'], print_r( $variation, true ) );
+
+		wp_delete_attachment( $variation['image']['id'], true );
 	}
 
 	/**
@@ -376,6 +378,8 @@ class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
+
+		wp_delete_attachment( $data[1]['image']['id'], true );
 	}
 
 	/**

--- a/unit-tests/Tests/Version2/products.php
+++ b/unit-tests/Tests/Version2/products.php
@@ -196,6 +196,7 @@ class Products_API_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'Dr1Bczxq4q', $data['images'][0]['src'] );
 		$this->assertContains( 'test upload image', $data['images'][0]['alt'] );
 		$product->delete( true );
+		wp_delete_attachment( $data['images'][0]['id'], true );
 
 		// test variable product (variations are tested in product-variations.php).
 		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();

--- a/unit-tests/Tests/Version3/product-variations.php
+++ b/unit-tests/Tests/Version3/product-variations.php
@@ -214,6 +214,8 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'], print_r( $variation, true ) );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'], print_r( $variation, true ) );
 		$this->assertContains( 'test upload image', $variation['image']['alt'], print_r( $variation, true ) );
+
+		wp_delete_attachment( $variation['image']['id'], true );
 	}
 
 	/**
@@ -378,6 +380,8 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
+
+		wp_delete_attachment( $data[1]['image']['id'], true );
 	}
 
 	/**

--- a/unit-tests/Tests/Version3/products.php
+++ b/unit-tests/Tests/Version3/products.php
@@ -199,6 +199,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'Dr1Bczxq4q', $data['images'][0]['src'] );
 		$this->assertContains( 'test upload image', $data['images'][0]['alt'] );
 		$product->delete( true );
+		wp_delete_attachment( $data['images'][0]['id'], true );
 
 		// test variable product (variations are tested in product-variations.php).
 		$product  = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();

--- a/unit-tests/Tests/Version4/ProductVariations.php
+++ b/unit-tests/Tests/Version4/ProductVariations.php
@@ -232,6 +232,8 @@ class ProductVariations extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'], print_r( $variation, true ) );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'], print_r( $variation, true ) );
 		$this->assertContains( 'test upload image', $variation['image']['alt'], print_r( $variation, true ) );
+
+		wp_delete_attachment( $variation['image']['id'], true );
 	}
 
 	/**
@@ -393,6 +395,8 @@ class ProductVariations extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
+
+		wp_delete_attachment( $data[1]['image']['id'], true );
 	}
 
 	/**

--- a/unit-tests/Tests/Version4/Products.php
+++ b/unit-tests/Tests/Version4/Products.php
@@ -242,6 +242,7 @@ class Products extends WC_REST_Unit_Test_Case {
 		$this->assertContains( 'Dr1Bczxq4q', $data['images'][0]['src'] );
 		$this->assertContains( 'test upload image', $data['images'][0]['alt'] );
 		$product->delete( true );
+		wp_delete_attachment( $data['images'][0]['id'], true );
 
 		// test variable product (variations are tested in product-variations.php).
 		$product  = ProductHelper::create_variation_product();

--- a/unit-tests/bin/install.sh
+++ b/unit-tests/bin/install.sh
@@ -181,6 +181,9 @@ install_deps() {
 
 	git clone --depth 1 https://github.com/woocommerce/woocommerce.git
 
+	cd "woocommerce"
+	composer install
+
 	cd "$WP_CORE_DIR"
 	php wp-cli.phar plugin activate woocommerce
 


### PR DESCRIPTION
This PR fixes a problem in the script that configures the environment to run the unit tests in the Travis build jobs. The script was not running `composer install` in the WooCommerce directory, leaving it installation incomplete and thus the tests were failing.

To fix this problem, this PR adds a call to `composer install` right after WooCommerce is downloaded in the setup script (`unit-tests/bin/install.sh`).

After the changes described above, when the Travis build started running the tests again, a failign test was revealed. This test was fixed in commit d789631. 