### PR TITLE
Removed MaxMind from System Status

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -793,7 +793,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		return array(
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
 			'database_prefix'        => $wpdb->prefix,
-			'maxmind_geoip_database' => WC_Geolocation::get_local_database_path(),
+			'maxmind_geoip_database' => '',
 			'database_tables'        => $tables,
 			'database_size'          => $database_size,
 		);

--- a/src/Controllers/Version4/SystemStatus.php
+++ b/src/Controllers/Version4/SystemStatus.php
@@ -295,12 +295,6 @@ class SystemStatus extends AbstractController {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
-						'maxmind_geoip_database' => array(
-							'description' => __( 'MaxMind GeoIP database.', 'woocommerce-rest-api' ),
-							'type'        => 'string',
-							'context'     => array( 'view' ),
-							'readonly'    => true,
-						),
 						'database_tables'        => array(
 							'description' => __( 'Database tables.', 'woocommerce-rest-api' ),
 							'type'        => 'array',

--- a/src/Controllers/Version4/Utilities/DatabaseInformation.php
+++ b/src/Controllers/Version4/Utilities/DatabaseInformation.php
@@ -117,7 +117,6 @@ class DatabaseInformation {
 		return array(
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
 			'database_prefix'        => $wpdb->prefix,
-			'maxmind_geoip_database' => '',
 			'database_tables'        => $tables,
 			'database_size'          => $database_size,
 		);

--- a/src/Controllers/Version4/Utilities/DatabaseInformation.php
+++ b/src/Controllers/Version4/Utilities/DatabaseInformation.php
@@ -117,7 +117,7 @@ class DatabaseInformation {
 		return array(
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
 			'database_prefix'        => $wpdb->prefix,
-			'maxmind_geoip_database' => \WC_Geolocation::get_local_database_path(),
+			'maxmind_geoip_database' => '',
 			'database_tables'        => $tables,
 			'database_size'          => $database_size,
 		);

--- a/unit-tests/Tests/Version2/system-status.php
+++ b/unit-tests/Tests/Version2/system-status.php
@@ -101,7 +101,6 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
-		$this->assertEquals( WC_Geolocation::get_local_database_path(), $database['maxmind_geoip_database'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], print_r( $database, true ) );
 	}

--- a/unit-tests/Tests/Version3/system-status.php
+++ b/unit-tests/Tests/Version3/system-status.php
@@ -104,7 +104,6 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
-		$this->assertEquals( WC_Geolocation::get_local_database_path(), $database['maxmind_geoip_database'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], wc_print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], wc_print_r( $database, true ) );
 	}

--- a/unit-tests/Tests/Version4/SystemStatus.php
+++ b/unit-tests/Tests/Version4/SystemStatus.php
@@ -123,7 +123,6 @@ class SystemStatus extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
-		$this->assertEquals( \WC_Geolocation::get_local_database_path(), $database['maxmind_geoip_database'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], wc_print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], wc_print_r( $database, true ) );
 	}


### PR DESCRIPTION
`WC_Geolocation::get_local_database_path()` will get deprecated by https://github.com/woocommerce/woocommerce/pull/25378
So we need to deprecate it on v2 and v3, for v4 I'm removing this code.