### PR TITLE
Fix unit tests to match new tested method behavior

### DIFF
--- a/unit-tests/Tests/Version2/shipping-zones.php
+++ b/unit-tests/Tests/Version2/shipping-zones.php
@@ -55,7 +55,7 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones', $routes );
-		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<id>[\d-]+)', $routes );
+		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<id>[\d]+)', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<id>[\d]+)/locations', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<zone_id>[\d]+)/methods', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping/zones/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d]+)', $routes );

--- a/unit-tests/Tests/Version3/shipping-zones.php
+++ b/unit-tests/Tests/Version3/shipping-zones.php
@@ -57,7 +57,7 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( '/wc/v3/shipping/zones', $routes );
-		$this->assertArrayHasKey( '/wc/v3/shipping/zones/(?P<id>[\d-]+)', $routes );
+		$this->assertArrayHasKey( '/wc/v3/shipping/zones/(?P<id>[\d]+)', $routes );
 		$this->assertArrayHasKey( '/wc/v3/shipping/zones/(?P<id>[\d]+)/locations', $routes );
 		$this->assertArrayHasKey( '/wc/v3/shipping/zones/(?P<zone_id>[\d]+)/methods', $routes );
 		$this->assertArrayHasKey( '/wc/v3/shipping/zones/(?P<zone_id>[\d]+)/methods/(?P<instance_id>[\d]+)', $routes );


### PR DESCRIPTION
This PR updates two unit tests that were failing
(https://travis-ci.org/woocommerce/woocommerce-rest-api/jobs/637678251#L707),
after the behavior of the method
WC_REST_Shipping_Zones_V2_Controller::register_routes() changed in PR #104.