### PR TITLE
Revert "Fixed type numeric type on products and variations schema"

### DIFF
--- a/src/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -441,18 +441,18 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				),
 				'price'                 => array(
 					'description' => __( 'Current variation price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'regular_price'         => array(
 					'description' => __( 'Variation regular price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'sale_price'            => array(
 					'description' => __( 'Variation sale price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'date_on_sale_from'     => array(
@@ -595,7 +595,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				'weight'                => array(
 					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce-rest-api' ), $weight_unit ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'dimensions'            => array(
@@ -606,19 +606,19 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 						'length' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 					),

--- a/src/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-products-controller.php
@@ -786,18 +786,18 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				),
 				'price'                 => array(
 					'description' => __( 'Current product price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'regular_price'         => array(
 					'description' => __( 'Product regular price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'sale_price'            => array(
 					'description' => __( 'Product sale price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'date_on_sale_from'     => array(
@@ -962,7 +962,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				'weight'                => array(
 					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce-rest-api' ), $weight_unit ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'dimensions'            => array(
@@ -973,19 +973,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 						'length' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product length (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product width (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product height (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 					),

--- a/src/Controllers/Version4/ProductVariations.php
+++ b/src/Controllers/Version4/ProductVariations.php
@@ -207,18 +207,18 @@ class ProductVariations extends Products {
 				),
 				'price'                 => array(
 					'description' => __( 'Current variation price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'regular_price'         => array(
 					'description' => __( 'Variation regular price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'sale_price'            => array(
 					'description' => __( 'Variation sale price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'date_on_sale_from'     => array(
@@ -361,7 +361,7 @@ class ProductVariations extends Products {
 				'weight'                => array(
 					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce-rest-api' ), $weight_unit ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'dimensions'            => array(
@@ -372,19 +372,19 @@ class ProductVariations extends Products {
 						'length' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 					),

--- a/src/Controllers/Version4/Products.php
+++ b/src/Controllers/Version4/Products.php
@@ -155,18 +155,18 @@ class Products extends AbstractObjectsController {
 				),
 				'price'                 => array(
 					'description' => __( 'Current product price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'regular_price'         => array(
 					'description' => __( 'Product regular price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'sale_price'            => array(
 					'description' => __( 'Product sale price.', 'woocommerce-rest-api' ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'date_on_sale_from'     => array(
@@ -331,7 +331,7 @@ class Products extends AbstractObjectsController {
 				'weight'                => array(
 					/* translators: %s: weight unit */
 					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce-rest-api' ), $weight_unit ),
-					'type'        => 'number',
+					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'dimensions'            => array(
@@ -342,19 +342,19 @@ class Products extends AbstractObjectsController {
 						'length' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product length (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'width'  => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product width (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 						'height' => array(
 							/* translators: %s: dimension unit */
 							'description' => sprintf( __( 'Product height (%s).', 'woocommerce-rest-api' ), $dimension_unit ),
-							'type'        => 'number',
+							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
 					),


### PR DESCRIPTION
Reverts woocommerce/woocommerce-rest-api#84

Closes #111

**Test instructions:**

1. Create a product with regular price, sale price, weight and dimensions (by REST API or on the admin interface)
2. Try edit your product created on step on by the REST API, those values to an empty string, or null, or something else in an attempt to clean those values, since not all products are required to have sale price, weight or dimensions, check that nothing works to set empty those data.
3. Apply this patch and try edit by the REST API again, and check that now it's possible to clean out those values.

