### PR TITLE
Query order notes by `comment_date`

### DIFF
--- a/src/Controllers/Version4/OrderNotes.php
+++ b/src/Controllers/Version4/OrderNotes.php
@@ -183,6 +183,22 @@ class OrderNotes extends AbstractController {
 			);
 		}
 
+		$args['date_query'] = array();
+		if ( isset( $request[ 'created_since' ] ) || isset( $request[ 'created_before' ] ) ) {
+			$date = [
+				'column' => 'comment_date',
+			];
+
+			if (isset( $request[ 'created_since' ] ) && !empty( $request[ 'created_since' ] )) {
+				$date['after'] = $request[ 'created_since' ];
+			}
+
+			if (isset( $request[ 'created_before' ] ) && !empty( $request[ 'created_before' ] )) {
+				$date['before'] = $request[ 'created_before' ];
+			}
+			$args['date_query'][] = $date;
+		}
+
 		remove_filter( 'comments_clauses', array( 'WC_Comments', 'exclude_order_comments' ), 10 );
 
 		$notes = get_comments( $args );
@@ -441,6 +457,18 @@ class OrderNotes extends AbstractController {
 			'type'              => 'string',
 			'enum'              => array( 'any', 'customer', 'internal' ),
 			'sanitize_callback' => 'sanitize_key',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['created_since'] = array(
+			'description'       => __( 'Filter notes by since created date.', 'woocommerce-rest-api' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['created_before'] = array(
+			'description'       => __( 'Filter notes by before created date.', 'woocommerce-rest-api' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 


### PR DESCRIPTION
Allow order notes to be queried by created_since, created_before.