### PR TITLE
Post product default status should be publish

### DIFF
--- a/src/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/src/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -697,7 +697,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 
 		// Post status.
 		if ( isset( $request['status'] ) ) {
-			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );
+			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'publish' );
 		}
 
 		// Post slug.

--- a/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -754,7 +754,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Post status.
 		if ( isset( $request['status'] ) ) {
-			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );
+			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'publish' );
 		}
 
 		// Post slug.

--- a/src/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-products-controller.php
@@ -336,7 +336,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Post status.
 		if ( isset( $request['status'] ) ) {
-			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );
+			$product->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'publish' );
 		}
 
 		// Post slug.


### PR DESCRIPTION
[V3](http://woocommerce.github.io/woocommerce-rest-api-docs/#product-properties
), [V2](http://woocommerce.github.io/woocommerce-rest-api-docs/wp-api-v2.html#product-properties) and [V1](http://woocommerce.github.io/woocommerce-rest-api-docs/wp-api-v1.html#product-properties
) state that the default status for a product is `publish`.

If no `status` value is passed in the POST request payload, the product will be created with the status of default value `publish`.
If `status: null` is passed in the payload, the product will be created in the `draft` status.

Seems like unintentional behaviour here. If this is too big a change for the API then I think the documentation should reflect this behaviour at the very least. Apologies in advance if I'm off the mark here, not super familiar with PHP.