### PR TITLE
Clear Action Scheduler Transients

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -420,6 +420,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				wc_delete_product_transients();
 				wc_delete_shop_order_transients();
 				delete_transient( 'wc_count_comments' );
+				delete_transient( 'as_comment_count' );
 
 				$attribute_taxonomies = wc_get_attribute_taxonomies();
 


### PR DESCRIPTION
Currently when Clear Transients action is performed via System Tools, the Action Scheduler Transients are not cleared resulting in incorrect comment counts.

Also Fixes https://github.com/woocommerce/woocommerce/issues/25750 