### PR TITLE
Change access modifier of get_public_batch_schema

### DIFF
--- a/src/Controllers/Version4/Utilities/BatchTrait.php
+++ b/src/Controllers/Version4/Utilities/BatchTrait.php
@@ -87,7 +87,7 @@ trait BatchTrait {
 	 *
 	 * @return array
 	 */
-	protected function get_public_batch_schema() {
+	public function get_public_batch_schema() {
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
 			'title'      => 'batch',


### PR DESCRIPTION
In BatchTrait, the access modifier of `get_public_batch_schema` is protected, however this trait is used by `AbstractController` which inherits from `WP_REST_Controller`. The class `WP_REST_Controller` also has a method called `get_public_batch_schema`, this causes access modifier conflict and generate warnings in console if you this class is loaded. 

This PR makes the access modifiers consistent with each other.