### PR TITLE
Added files that should be ignored on export to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,8 @@
 /vendor export-ignore
 /README.md export-ignore
 /readme.txt export-ignore
+/composer.* export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore
+/renovate.json export-ignore
+/unit-tests export-ignore


### PR DESCRIPTION
The jetpack-autoloader used by WooCommerce requires version information in order to ensure the latest files are loaded. A consequence of this is that zip files generated from `master` appear usable but aren't. Running `composer install` against this package will result in a default version of `1.0.0.0`, which is less than it should be, and thus not used.

This PR sets all of the build files to `export-ignore` so they are not included in the package. This does make the package unusable unless cloned, but as it stands, it already is (it just doesn't tell you).