### PR TITLE
add X-WP-Total headers to product attribute API calls

### DIFF
--- a/src/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
+++ b/src/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
@@ -228,7 +228,13 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 			$data[] = $attribute;
 		}
 
-		return rest_ensure_response( $data );
+		$response = rest_ensure_response( $data );
+
+		// This API call always returns all product attributes due to retrieval from the object cache.
+		$response->header( 'X-WP-Total', count( $data ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
 	}
 
 	/**

--- a/src/Controllers/Version4/ProductAttributes.php
+++ b/src/Controllers/Version4/ProductAttributes.php
@@ -130,7 +130,13 @@ class ProductAttributes extends AbstractController {
 			$data[]    = $attribute;
 		}
 
-		return rest_ensure_response( $data );
+		$response = rest_ensure_response( $data );
+
+		// This API call always returns all product attributes due to retrieval from the object cache.
+		$response->header( 'X-WP-Total', count( $data ) );
+		$response->header( 'X-WP-TotalPages', 1 );
+
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
Due to product attributes being retrieved from the object cache, there is no support for pagination, and therefore (I assume) no `X-WP-Total` and `X-WP-TotalPages` headers in the response.

We have a third-party app using the REST API and it expects and uses those headers to determine how many pages and/or results to expect and fetch.