### PR TITLE
Fix expiry date fields in coupon schema definitions

### DIFF
--- a/src/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/src/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -453,7 +453,7 @@ class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {
 				),
 				'expiry_date' => array(
 					'description' => __( 'UTC DateTime when the coupon expires.', 'woocommerce-rest-api' ),
-					'type'        => 'string',
+					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'usage_count' => array(

--- a/src/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -385,12 +385,12 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 				),
 				'date_expires'                => array(
 					'description' => __( "The date the coupon expires, in the site's timezone.", 'woocommerce-rest-api' ),
-					'type'        => 'string',
+					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'date_expires_gmt'            => array(
 					'description' => __( 'The date the coupon expires, as GMT.', 'woocommerce-rest-api' ),
-					'type'        => 'string',
+					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'usage_count'                 => array(


### PR DESCRIPTION
The expiry date for all API versions had a `string` type but should have `date-time`.

This only affects the schema, the behaviour was already correct.

Thanks