### PR TITLE
add clear template cache tool

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -566,6 +566,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					$message = __( 'Template cache cleared.', 'woocommerce-rest-api' );
 				} else {
 					$message = __( 'The active version of WooCommerce does not support template cache clearing.', 'woocommerce-rest-api' );
+					$ran = false;
 				}
 				break;
 

--- a/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -566,6 +566,9 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					$message = __( 'Template cache cleared.', 'woocommerce-rest-api' );
 				} else {
 					$message = __( 'The active version of WooCommerce does not support template cache clearing.', 'woocommerce-rest-api' );
+				}
+				break;
+
 			case 'verify_db_tables':
 				if ( ! method_exists( 'WC_Install', 'verify_base_tables' ) ) {
 					$message = __( 'You need WooCommerce 4.2 or newer to run this tool.', 'woocommerce-rest-api' );

--- a/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -167,6 +167,15 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This tool will delete all customer session data from the database, including current carts and saved carts in the database.', 'woocommerce-rest-api' )
 				),
 			),
+			'clear_template_cache'               => array(
+				'name'   => __( 'Clear template cache', 'woocommerce-rest-api' ),
+				'button' => __( 'Clear', 'woocommerce-rest-api' ),
+				'desc'   => sprintf(
+					'<strong class="red">%1$s</strong> %2$s',
+					__( 'Note:', 'woocommerce-rest-api' ),
+					__( 'This tool will empty the template cache.', 'woocommerce-rest-api' )
+				),
+			),
 			'install_pages'                      => array(
 				'name'   => __( 'Create default WooCommerce pages', 'woocommerce-rest-api' ),
 				'button' => __( 'Create pages', 'woocommerce-rest-api' ),
@@ -204,6 +213,10 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 		// Jetpack does the image resizing heavy lifting so you don't have to.
 		if ( ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) || ! apply_filters( 'woocommerce_background_image_regeneration', true ) ) {
 			unset( $tools['regenerate_thumbnails'] );
+		}
+
+		if ( ! function_exists( 'wc_clear_template_cache' ) ) {
+			unset( $tools['clear_template_cache'] );
 		}
 
 		return apply_filters( 'woocommerce_debug_tools', $tools );
@@ -536,6 +549,11 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				// This method will make sure the database updates are executed even if cron is disabled. Nothing will happen if the updates are already running.
 				do_action( 'wp_' . $blog_id . '_wc_updater_cron' );
 				$message = __( 'Database upgrade routine has been scheduled to run in the background.', 'woocommerce-rest-api' );
+				break;
+
+			case 'clear_template_cache':
+				wc_clear_template_cache();
+				$message = __( 'Template cache cleared.', 'woocommerce-rest-api' );
 				break;
 
 			default:

--- a/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -552,8 +552,12 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				break;
 
 			case 'clear_template_cache':
-				wc_clear_template_cache();
-				$message = __( 'Template cache cleared.', 'woocommerce-rest-api' );
+				if ( function_exists( 'wc_clear_template_cache' ) ) {
+					wc_clear_template_cache();
+					$message = __( 'Template cache cleared.', 'woocommerce-rest-api' );
+				} else {
+					$message = __( 'The active version of WooCommerce does not support template cache clearing.', 'woocommerce-rest-api' );
+				}
 				break;
 
 			default:


### PR DESCRIPTION
Note this needs https://github.com/woocommerce/woocommerce/pull/26752 merged to work.

Use testing instructions from https://github.com/woocommerce/woocommerce/pull/26752.

Test failures are not related to this PR.