### PR TITLE
Adds Database Name parameter to WC Rest API - System Status Report response 

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -297,6 +297,12 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
+						'database_name'          => array(
+							'description' => __( 'Database prefix.', 'woocommerce-rest-api' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
 						'database_prefix'        => array(
 							'description' => __( 'Database prefix.', 'woocommerce-rest-api' ),
 							'type'        => 'string',
@@ -854,6 +860,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		// Return all database info. Described by JSON Schema.
 		return array(
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
+			'database_name'          => defined( 'DB_NAME' ) ? DB_NAME : '',
 			'database_prefix'        => $wpdb->prefix,
 			'maxmind_geoip_database' => '',
 			'database_tables'        => $tables,

--- a/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -298,7 +298,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 							'readonly'    => true,
 						),
 						'database_name'          => array(
-							'description' => __( 'Database prefix.', 'woocommerce-rest-api' ),
+							'description' => __( 'Database name.', 'woocommerce-rest-api' ),
 							'type'        => 'string',
 							'context'     => array( 'view' ),
 							'readonly'    => true,

--- a/src/Controllers/Version4/SystemStatus.php
+++ b/src/Controllers/Version4/SystemStatus.php
@@ -289,6 +289,12 @@ class SystemStatus extends AbstractController {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
+						'database_name'          => array(
+							'description' => __( 'Database name.', 'woocommerce-rest-api' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
 						'database_prefix'        => array(
 							'description' => __( 'Database prefix.', 'woocommerce-rest-api' ),
 							'type'        => 'string',

--- a/src/Controllers/Version4/Utilities/DatabaseInformation.php
+++ b/src/Controllers/Version4/Utilities/DatabaseInformation.php
@@ -116,6 +116,7 @@ class DatabaseInformation {
 		// Return all database info. Described by JSON Schema.
 		return array(
 			'wc_database_version'    => get_option( 'woocommerce_db_version' ),
+			'database_name'          => defined( 'DB_NAME' ) ? DB_NAME : '',
 			'database_prefix'        => $wpdb->prefix,
 			'database_tables'        => $tables,
 			'database_size'          => $database_size,

--- a/unit-tests/Tests/Version2/system-status.php
+++ b/unit-tests/Tests/Version2/system-status.php
@@ -100,6 +100,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$database = (array) $data['database'];
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
+		$this->assertEquals( DB_NAME, $database['database_name'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], print_r( $database, true ) );

--- a/unit-tests/Tests/Version3/system-status.php
+++ b/unit-tests/Tests/Version3/system-status.php
@@ -138,6 +138,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$database = (array) $data['database'];
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
+		$this->assertEquals( DB_NAME, $database['database_name'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], wc_print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], wc_print_r( $database, true ) );

--- a/unit-tests/Tests/Version4/SystemStatus.php
+++ b/unit-tests/Tests/Version4/SystemStatus.php
@@ -122,6 +122,7 @@ class SystemStatus extends WC_REST_Unit_Test_Case {
 		$database = (array) $data['database'];
 
 		$this->assertEquals( get_option( 'woocommerce_db_version' ), $database['wc_database_version'] );
+		$this->assertEquals( DB_NAME, $database['database_name'] );
 		$this->assertEquals( $wpdb->prefix, $database['database_prefix'] );
 		$this->assertArrayHasKey( 'woocommerce', $database['database_tables'], wc_print_r( $database, true ) );
 		$this->assertArrayHasKey( $wpdb->prefix . 'woocommerce_payment_tokens', $database['database_tables']['woocommerce'], wc_print_r( $database, true ) );


### PR DESCRIPTION
### Changes
Added the parameter `database_name` to System Status Report API response (v2, v4). The changes are related to the fix for https://github.com/woocommerce/woocommerce/issues/26995

Also, added Unit Tests for checking the same against the constant `DB_NAME` (v2, v3, v4)