### PR TITLE
Fix compatibility for WP 5.5

### DIFF
--- a/src/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -511,7 +511,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version2/class-wc-rest-customers-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-customers-v2-controller.php
@@ -350,7 +350,7 @@ class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -410,7 +410,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),
@@ -432,13 +432,13 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'name'         => array(
 								'description' => __( 'Product name.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'product_id'   => array(
 								'description' => __( 'Product ID.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'integer', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
@@ -535,7 +535,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),

--- a/src/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1170,7 +1170,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),
@@ -1191,12 +1191,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'name'         => array(
 								'description' => __( 'Product name.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'product_id'   => array(
 								'description' => __( 'Product ID.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'integer' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'variation_id' => array(
@@ -1282,7 +1282,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1373,7 +1373,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1397,12 +1397,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'method_title' => array(
 								'description' => __( 'Shipping method name.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'method_id'    => array(
 								'description' => __( 'Shipping method ID.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'instance_id'  => array(
@@ -1464,7 +1464,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1488,7 +1488,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'name'       => array(
 								'description' => __( 'Fee name.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'tax_class'  => array(
@@ -1562,7 +1562,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1586,7 +1586,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'code'         => array(
 								'description' => __( 'Coupon code.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 							'discount'     => array(
@@ -1620,7 +1620,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-											'type'        => 'mixed',
+											'type'        => array( 'string', 'null' ),
 											'context'     => array( 'view', 'edit' ),
 										),
 									),

--- a/src/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -799,7 +799,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 				),
 				'manage_stock'          => array(
 					'description' => __( 'Stock management at variation level.', 'woocommerce-rest-api' ),
-					'type'        => 'mixed',
+					'type'        => array( 'boolean', 'null' ),
 					'default'     => false,
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -982,7 +982,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -2084,7 +2084,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/src/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -530,12 +530,18 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 				),
 				'value'       => array(
 					'description' => __( 'Setting value.', 'woocommerce-rest-api' ),
-					'type'        => 'mixed',
+					'type'        => array( 'string', 'array', 'null' ),
+					'items'       => array(
+						'type' => array( 'string', 'null' ),
+					),
 					'context'     => array( 'view', 'edit' ),
 				),
 				'default'     => array(
 					'description' => __( 'Default value for the setting.', 'woocommerce-rest-api' ),
-					'type'        => 'mixed',
+					'type'        => array( 'string', 'array', 'null' ),
+					'items'       => array(
+						'type' => array( 'string', 'null' ),
+					),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/src/Controllers/Version3/class-wc-rest-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-controller.php
@@ -78,6 +78,35 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Compatibility functions for WP 5.5, since custom types are not supported anymore.
+	 * See @link https://core.trac.wordpress.org/changeset/48306
+	 *
+	 * @param string $method Optional. HTTP method of the request.
+	 *
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = WP_REST_Server::CREATABLE ) {
+
+		$endpoint_args = parent::get_endpoint_args_for_item_schema( $method );
+
+		if ( false === strpos( WP_REST_Server::EDITABLE, $method ) ) {
+			return $endpoint_args;
+		}
+
+		foreach ( $endpoint_args as $field_id => $params ) {
+			/**
+			 * Custom types are not supported as of WP 5.5, this translates type => 'date-time' to type => 'string' with format date-time.
+			 */
+			if ( 'date-time' === $params['type'] ) {
+				$endpoint_args[ $field_id ]['type']   = 'string';
+				$endpoint_args[ $field_id ]['format'] = 'date-time';
+			}
+		}
+
+		return $endpoint_args;
+	}
+
+	/**
 	 * Get normalized rest base.
 	 *
 	 * @return string

--- a/src/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -91,6 +91,8 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		return true;
 	}
 
+
+
 	/**
 	 * Get object permalink.
 	 *

--- a/src/Controllers/Version3/class-wc-rest-customers-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-customers-controller.php
@@ -293,7 +293,7 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -736,7 +736,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1288,7 +1288,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => 'mixed',
+								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/src/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/src/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -199,12 +199,18 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 				),
 				'value'       => array(
 					'description' => __( 'Setting value.', 'woocommerce-rest-api' ),
-					'type'        => 'mixed',
+					'type'        => array( 'string', 'array', 'null' ),
+					'items'       => array(
+						'type' => array( 'string', 'null' ),
+					),
 					'context'     => array( 'view', 'edit' ),
 				),
 				'default'     => array(
 					'description' => __( 'Default value for the setting.', 'woocommerce-rest-api' ),
-					'type'        => 'mixed',
+					'type'        => array( 'string', 'array', 'null' ),
+					'items'       => array(
+						'type' => array( 'string', 'null' ),
+					),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
This PR has a couple of changes in response to https://core.trac.wordpress.org/changeset/48306

1. Type `mixed` is now changed to appropriate scalar type with addition of `null`. So final type is now `array( {scalar}, 'null' )`. 
2. [High Impact] For settings API, the allowed type is now changed to `array`, `string`, `null`, and if an array, then allowed item type is `string` or `null`. This means that only one of nesting is now allowed for WooCommerce settings via API. Would appreciate the feedback here on if this is backward compatible or not. Looks like we have to mandatorily define the child properties if the native property is array or object. This means that just saying that type is `object` is not allowed, we have to define all the properties of children (and their children, etc if any).
3. Added a method to convert from `type => date-time` to `type => string, format => date-time`.